### PR TITLE
#22 - EC2에 Spring Boot 백엔드 배포 및 RDS 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Docker file
+
+# jdk17 Image Start
+FROM openjdk:17-jdk
+
+# 인자 정리 - jar
+ARG JAR_FILE=build/libs/*.jar
+
+# jar File Copy
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,8 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// build.gradle
+jar {
+	enabled = false
+}


### PR DESCRIPTION
- Spring Boot 백엔드 JAR 파일 빌드
- Spring Boot용 Docker 이미지 생성
- Spring Boot Docker 컨테이너를 EC2 인스턴스에 배포

- application.properties를 .gitignore에 추가하여 RDS 정보 보호함